### PR TITLE
Migrate to new Coalton syntax

### DIFF
--- a/src/atomic.lisp
+++ b/src/atomic.lisp
@@ -21,30 +21,30 @@
   (declare new (Word -> AtomicInteger))
   (define (new value)
     "Creates an `AtomicInteger' with initial value `value'."
-    (lisp AtomicInteger (value)
+    (lisp (-> AtomicInteger) (value)
       (bt2:make-atomic-integer :value value)))
 
-  (declare cas! (AtomicInteger -> Word -> Word -> Boolean))
+  (declare cas! (AtomicInteger * Word * Word -> Boolean))
   (define (cas! atomic old new)
     "If the current value of `atomic' is equal to `old', replace it with `new'.
 Returns True if the replacement was successful, otherwise False."
-    (lisp Boolean (atomic old new)
+    (lisp (-> Boolean) (atomic old new)
       (bt2:atomic-integer-compare-and-swap atomic old new)))
 
-  (declare decf! (AtomicInteger -> Word -> Word))
+  (declare decf! (AtomicInteger * Word -> Word))
   (define (decf! atomic delta)
     "Decrements the value of `atomic' by `delta'."
-    (lisp Word (atomic delta)
+    (lisp (-> Word) (atomic delta)
       (bt2:atomic-integer-decf atomic delta)))
 
-  (declare incf! (AtomicInteger -> Word -> Word))
+  (declare incf! (AtomicInteger * Word -> Word))
   (define (incf! atomic delta)
     "Increments the value of `atomic' by `delta'."
-    (lisp Word (atomic delta)
+    (lisp (-> Word) (atomic delta)
       (bt2:atomic-integer-incf atomic delta)))
 
   (declare read (AtomicInteger -> Word))
   (define (read atomic)
     "Returns the current value of `atomic'."
-    (lisp Word (atomic)
+    (lisp (-> Word) (atomic)
       (bt2:atomic-integer-value atomic))))

--- a/src/barrier.lisp
+++ b/src/barrier.lisp
@@ -20,7 +20,7 @@
     (cv        cv:ConditionVariable)
     (lock      lock:Lock))
 
-  (declare new (Unit -> Barrier))
+  (declare new (Void -> Barrier))
   (define (new)
     (Barrier (cell:new True) (cv:new) (lock:new)))
 

--- a/src/condition-variable.lisp
+++ b/src/condition-variable.lisp
@@ -16,33 +16,33 @@
   (define-type ConditionVariable
     "Wrapper for a native condition variable.")
 
-  (declare new (Unit -> ConditionVariable))
+  (declare new (Void -> ConditionVariable))
   (define (new)
     "Creates a condition variable."
-    (lisp ConditionVariable ()
+    (lisp (-> ConditionVariable) ()
       (bt2:make-condition-variable)))
 
-  (declare await (ConditionVariable -> lock:Lock -> Unit))
+  (declare await (ConditionVariable * lock:Lock -> Unit))
   (define (await cv lock)
     "Atomically release `lock' and enqueue the calling thread waiting for `cv'.
 The thread will resume when another thread has notified it using `notify-cv';
 it may also resume if interrupted by some external event or in other
 implementation-dependent circumstances: the caller must always test on waking
 that there is threading to be done, instead of assuming that it can go ahead."
-    (lisp Unit (cv lock)
+    (lisp (-> Unit) (cv lock)
       (bt2:condition-wait cv lock)
       Unit))
 
   (declare notify (ConditionVariable -> Unit))
   (define (notify cv)
     "Notify one of the threads waiting for `cv'."
-    (lisp Unit (cv)
+    (lisp (-> Unit) (cv)
       (bt2:condition-notify cv)
       Unit))
 
   (declare broadcast (ConditionVariable -> Unit))
   (define (broadcast cv)
     "Notify all of the threads waiting for `cv'."
-    (lisp Unit (cv)
+    (lisp (-> Unit) (cv)
       (bt2:condition-broadcast cv)
       Unit)))

--- a/src/lock.lisp
+++ b/src/lock.lisp
@@ -16,23 +16,23 @@
   (define-type Lock
     "Wrapper for a native non-recursive lock.")
 
-  (declare new (Unit -> Lock))
+  (declare new (Void -> Lock))
   (define (new)
     "Creates a non-recursive lock."
-    (lisp Lock ()
+    (lisp (-> Lock) ()
       (bt2:make-lock)))
 
   (declare acquire (Lock -> Boolean))
   (define (acquire lock)
     "Acquire `lock' for the calling thread."
-    (lisp Boolean (lock)
+    (lisp (-> Boolean) (lock)
       (bt2:acquire-lock lock)))
 
   (declare acquire-no-wait (Lock -> Boolean))
   (define (acquire-no-wait lock)
     "Acquire `lock' for the calling thread.
 Returns Boolean immediately, True if `lock' was acquired, False otherwise."
-    (lisp Boolean (lock)
+    (lisp (-> Boolean) (lock)
       (bt2:acquire-lock lock :wait nil)))
 
   (declare release (Lock -> (Result LispCondition Lock)))
@@ -43,11 +43,11 @@ thread. If other threads are waiting for the lock, the
 `acquire-lock' call in one of them will now be able to continue.
 
 Returns the lock."
-    (lisp (Result LispCondition Lock) (lock)
+    (lisp (-> Result LispCondition Lock) (lock)
       (cl:handler-case (Ok (bt2:release-lock lock))
         (cl:error (c) (Err c)))))
 
-  (declare with-lock-held (Lock -> (Unit -> :a) -> :a))
+  (declare with-lock-held (Lock * (Void -> :a) -> :a))
   (define (with-lock-held lock thunk)
     (acquire lock)
     (let ((result (thunk)))

--- a/src/mutex.lisp
+++ b/src/mutex.lisp
@@ -30,21 +30,21 @@
       (fn ()
         (cell:read (.cell mutex)))))
 
-  (declare swap! (Mutex :a -> :a -> :a))
+  (declare swap! (Mutex :a * :a -> :a))
   (define (swap! mutex value)
     "Replace the value held in a Mutex, returning the old value."
     (lock:with-lock-held (.lock mutex)
       (fn ()
         (cell:swap! (.cell mutex) value))))
 
-  (declare write! (Mutex :a -> :a -> :a))
+  (declare write! (Mutex :a * :a -> :a))
   (define (write! mutex value)
     "Set the value held in a Mutex, returning the new value."
     (lock:with-lock-held (.lock mutex)
       (fn ()
         (cell:write! (.cell mutex) value))) )
 
-  (declare update! (Mutex :a -> (:a -> :a) -> :a))
+  (declare update! (Mutex :a * (:a -> :a) -> :a))
   (define (update! mutex f)
     "Swap the value held in a Mutex with a transforming function."
     (lock:with-lock-held (.lock mutex)

--- a/src/recursive-lock.lisp
+++ b/src/recursive-lock.lisp
@@ -16,23 +16,23 @@
   (define-type RecursiveLock
     "Wrapper for a native recursive lock.")
 
-  (declare new (Unit -> RecursiveLock))
+  (declare new (Void -> RecursiveLock))
   (define (new)
     "Creates a non-recursive lock."
-    (lisp RecursiveLock ()
+    (lisp (-> RecursiveLock) ()
       (bt2:make-recursive-lock)))
 
   (declare acquire (RecursiveLock -> Boolean))
   (define (acquire lock)
     "Acquire `lock' for the calling thread."
-    (lisp Boolean (lock)
+    (lisp (-> Boolean) (lock)
       (bt2:acquire-recursive-lock lock)))
 
   (declare acquire-no-wait (RecursiveLock -> Boolean))
   (define (acquire-no-wait lock)
     "Acquire `lock' for the calling thread.
 Returns Boolean immediately, True if `lock' was acquired, False otherwise."
-    (lisp Boolean (lock)
+    (lisp (-> Boolean) (lock)
       (bt2:acquire-recursive-lock lock :wait nil)))
 
   (declare release (RecursiveLock -> (Result LispCondition RecursiveLock)))
@@ -43,11 +43,11 @@ thread. If other threads are waiting for the lock, the
 `acquire-lock' call in one of them will now be able to continue.
 
 Returns the lock."
-    (lisp (Result LispCondition RecursiveLock) (lock)
+    (lisp (-> Result LispCondition RecursiveLock) (lock)
       (cl:handler-case (Ok (bt2:release-recursive-lock lock))
         (cl:error (c) (Err c)))))
 
-  (declare with-lock-held (RecursiveLock -> (Unit -> :a) -> :a))
+  (declare with-lock-held (RecursiveLock * (Void -> :a) -> :a))
   (define (with-lock-held lock thunk)
     (acquire lock)
     (let ((result (thunk)))

--- a/src/semaphore.lisp
+++ b/src/semaphore.lisp
@@ -13,17 +13,17 @@
   (define-type Semaphore
     "Wrapper for a native semaphore.")
 
-  (declare new (Unit -> Semaphore))
+  (declare new (Void -> Semaphore))
   (define (new)
     "Creates a semaphore with initial count 0."
-    (lisp Semaphore ()
+    (lisp (-> Semaphore) ()
       (bt2:make-semaphore)))
 
-  (declare signal (Semaphore -> UFix -> Unit))
+  (declare signal (Semaphore * UFix -> Unit))
   (define (signal sem count)
     "Increment `sem' by `count'.
 If there are threads awaiting this semaphore, then `count' of them are woken up."
-    (lisp Unit (sem count)
+    (lisp (-> Unit) (sem count)
       (bt2:signal-semaphore sem :count count)
       Unit))
 
@@ -31,6 +31,6 @@ If there are threads awaiting this semaphore, then `count' of them are woken up.
   (define (await sem)
     "Decrement the count of `sem' by 1 if the count is larger than zero.
 If the count is zero, blocks until `sem' can be decremented."
-    (lisp Unit (sem)
+    (lisp (-> Unit) (sem)
       (bt2:wait-on-semaphore sem)
       Unit)))

--- a/src/thread.lisp
+++ b/src/thread.lisp
@@ -36,13 +36,13 @@
       (lisp (-> LispThread) (thread)
         thread)))
 
-  (declare spawn ((Unit -> :a) -> Thread :a))
+  (declare spawn ((Void -> :a) -> Thread :a))
   (define (spawn thunk)
     "Creates and returns a thread, which will call the function
 `thunk' with no arguments: when `thunk' returns, the thread terminates."
     (lisp (-> Thread :a) (thunk)
       (bt2:make-thread
-       (cl:lambda () (call-coalton-function thunk Unit)))))
+       (cl:lambda () (call-coalton-function thunk)))))
 
   (declare current-thread (Void -> LispThread))
   (define (current-thread)

--- a/src/thread.lisp
+++ b/src/thread.lisp
@@ -25,49 +25,49 @@
 
   (define-instance (Eq LispThread)
     (define (== a b)
-      (lisp Boolean (a b) (to-boolean (cl:eq a b)))))
+      (lisp (-> Boolean) (a b) (to-boolean (cl:eq a b)))))
 
   (define-instance (Eq (Thread :a))
     (define (== a b)
-      (lisp Boolean (a b) (to-boolean (cl:eq a b)))))
+      (lisp (-> Boolean) (a b) (to-boolean (cl:eq a b)))))
 
   (define-instance (Into (Thread :a) LispThread)
     (define (into thread)
-      (lisp LispThread (thread)
+      (lisp (-> LispThread) (thread)
         thread)))
 
   (declare spawn ((Unit -> :a) -> Thread :a))
   (define (spawn thunk)
     "Creates and returns a thread, which will call the function
 `thunk' with no arguments: when `thunk' returns, the thread terminates."
-    (lisp (Thread :a) (thunk)
+    (lisp (-> Thread :a) (thunk)
       (bt2:make-thread
        (cl:lambda () (call-coalton-function thunk Unit)))))
 
-  (declare current-thread (Unit -> LispThread))
+  (declare current-thread (Void -> LispThread))
   (define (current-thread)
     "Returns the thread object representing the calling thread."
-    (lisp LispThread ()
+    (lisp (-> LispThread) ()
       (bt2:current-thread)))
 
-  (declare all-threads (Unit -> (List LispThread)))
+  (declare all-threads (Void -> (List LispThread)))
   (define (all-threads)
     "Returns a fresh list of all running threads."
-    (lisp (List LispThread) ()
+    (lisp (-> List LispThread) ()
       (bt2:all-threads)))
 
   (declare join (Thread :a -> (Result LispCondition :a)))
   (define (join thread)
     "Wait until `thread' terminates, or if it has already terminated, return immediately."
-    (lisp (Result LispCondition :a) (thread)
+    (lisp (-> Result LispCondition :a) (thread)
       (cl:handler-case (Ok (bt2:join-thread thread))
         (cl:error (c) (Err c)))))
 
-  (declare interrupt ((Into :a LispThread) => :a -> (Unit -> Unit) -> (Result LispCondition :a)))
+  (declare interrupt ((Into :a LispThread) => :a * (Void -> Unit) -> (Result LispCondition :a)))
   (define (interrupt thread thunk)
     "Interrupt thread and call `thunk' within its dynamic context,
 then continue with the interrupted path of execution."
-    (lisp (Result LispCondition :a) (thread thunk)
+    (lisp (-> Result LispCondition :a) (thread thunk)
       (cl:handler-case
           (Ok (bt2:interrupt-thread
                thread
@@ -77,12 +77,12 @@ then continue with the interrupted path of execution."
   (declare destroy ((Into :a LispThread) => :a -> (Result LispCondition :a)))
   (define (destroy thread)
     "Terminates the thread `thread'."
-    (lisp (Result LispCondition :a) (thread)
+    (lisp (-> Result LispCondition :a) (thread)
       (cl:handler-case (Ok (bt2:destroy-thread thread))
         (cl:error (c) (Err c)))))
 
   (declare alive? ((Into :a LispThread) => :a -> Boolean))
   (define (alive? thread)
     "Returns True if `thread' has not finished or `destroy' has not been called on it."
-    (lisp Boolean (thread)
+    (lisp (-> Boolean) (thread)
       (bt2:thread-alive-p thread))))


### PR DESCRIPTION
Currently, `coalton-threads` isn't compiling against Coaton `main`. This PR migrates the library to the new syntax for a few different parts of Coalton:

* Return values for lisp forms need (-> ...) syntax
* Function arguments use * not ->
* No argument functions use Void not Unit